### PR TITLE
Instructions for certificate renewal

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,16 @@ $ [sudo] certbot run --domains VHOST \
 Simply follow the steps presented on the screen to complete the process.
 
 
+For certificate **renewal** execute the same command, but change the option 'run' to 'certonly':
+```
+$ [sudo] certbot certonly --domains VHOST \
+            --authenticator letsencrypt-gandi:gandi-shs \
+                --letsencrypt-gandi:gandi-shs-name SHS-NAME \
+                --letsencrypt-gandi:gandi-shs-vhost VHOST \
+                --letsencrypt-gandi:gandi-shs-api-key API-KEY \
+            --installer letsencrypt-gandi:gandi-shs
+```
+
 #### Scripting 
 
 You can also create scripts to make this process easier for certificate creation and renewal. 


### PR DESCRIPTION
Add basic instructions to the readme about the change in the certbot command for certificate renewal: replace ‚run‘ with ‚certonly‘. Example included.
