### PR TITLE
Add support for Node.js following Python example

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,10 @@ If the plugin was correctly installed, you can proceed to using it.
 
 #### Limitations
 
-* Currently, **only PHP, Ruby and Python instances are supported** by the plugin. Node.js instances are not yet supported by the plugin, but you can refer to [our tutorial  for a walkthrough](https://wiki.gandi.net/tutorials/letsencrypt).
+* Currently, only PHP and Ruby instances will work without modification of your code (in most cases). Simply follow the instructions and the plugin will take care of obtaining and installing the certificates for you.
+* Python and Node.js instance users must add a special route to their application prior to using the plugin (examples provided below)
 
-##### Limitations of Python instances
+##### Python instances
 
 Python applications are handled through a [WSGI application in Gandi](https://wiki.gandi.net/en/simple/instance/python) so to get this plugin to work, you need to configure your application to serve a directory called `.well-known` statically from the application folder.
 
@@ -115,6 +116,19 @@ If you are using Django, you can do this by adding a route to your **urls.py** f
 ```
 
 After doing that, deploy your application to your Simple Hosting instance and use this plugin to obtain and install a certificate.
+
+##### Node.js instances
+
+To use this plugin with Node.js applications, you will have to create a special route to serve static files from a directory called `.well-know`.
+
+For example, if you're using the Express framework :
+
+```javascript
+app.use(express.static('.well-known'));
+
+```
+
+Once you have added the route to the application, deploy it to your Simple Hosting instance before following the rest of the instructions. 
 
 #### Instructions
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ After doing that, deploy your application to your Simple Hosting instance and us
 
 ##### Node.js instances
 
-To use this plugin with Node.js applications, you will have to create a special route to serve static files from a directory called `.well-know`.
+To use this plugin with Node.js applications, you will have to create a special route to serve static files from a directory called `.well-known`.
 
 For example, if you're using the Express framework :
 

--- a/letsencrypt_gandi/shs.py
+++ b/letsencrypt_gandi/shs.py
@@ -127,13 +127,6 @@ class GandiSHSConfigurator(common.Plugin):
 
         self.vhost = self.conf('vhost')
 
-        if not re.match('^(php|ruby|python)', self.shs_info['type']):
-            raise errors.PluginError(
-                "Sorry, only php and ruby instances are supported for now, "
-                "we're doing our best to get everything supported with "
-                "Let's Encrypt. Please check {0} for newer versions."
-                .format(UPSTREAM_URL))
-
     def _api_key_from_gandi_cli(self):
         """Got cli? grab it https://cli.gandi.net
 
@@ -200,7 +193,7 @@ class GandiSHSConfigurator(common.Plugin):
     def _base_path(self):
         if re.match('^php', self.shs_info['type']):
             return 'vhosts/{vhost}/htdocs/'.format(vhost=self.vhost)
-        elif re.match('^python', self.shs_info['type']):
+        elif re.match('^(python|nodejs)', self.shs_info['type']):
             return 'vhosts/default'
         # if ruby
         return 'vhosts/default/public'


### PR DESCRIPTION
We have added support for Python instances through specific instructions in the README and allowing Python instances in the code.

This PR does the same for Node.js instances (and deletes the language checks).
