### PR TITLE
Configure Docker container to add the plugin to cerbot

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM quay.io/letsencrypt/letsencrypt:latest
+
+MAINTAINER Gandi <https://github.com/Gandi/letsencrypt-gandi>
+
+# Install sftp
+RUN apt-get update && apt-get install -y openssh-client
+
+# Copy plugin files
+COPY letsencrypt_gandi	/opt/letsencrypt-gandi/letsencrypt_gandi
+COPY setup.py 			/opt/letsencrypt-gandi/setup.py
+
+# Register the plugin
+RUN cd /opt/letsencrypt-gandi && /opt/certbot/venv/bin/pip install -e .
+
+ENTRYPOINT [ "certbot" ]


### PR DESCRIPTION
After a failing attempt to install certbot + letsencrypt-gandi on my Mac, I tried with Docker and it works like a charm.

After cloning the repository, the container can be created with the following command:
```bash
docker build -t letsencrypt-gandi . 
```

Then I create an alias to run certbot, SSH key and storage directories must be exposed:
```bash
alias certbot='docker run -it --rm --name letsencrypt-gandi \
    -v "$HOME/.letsencrypt/etc:/etc/letsencrypt" \
    -v "$HOME/.letsencrypt/lib:/var/lib/letsencrypt" \
    -v "$HOME/.letsencrypt/log:/var/log/letsencrypt" \
    -v "$HOME/.ssh/known_hosts:/root/.ssh/known_hosts" \
    -v "$HOME/.ssh/id_rsa:/root/.ssh/id_rsa" \
    letsencrypt-gandi'
```

The command `certbot` can be used like a local command:
```bash
certbot run --domains VHOST \
        --authenticator letsencrypt-gandi:gandi-shs \
            --letsencrypt-gandi:gandi-shs-name SHS-NAME \
            --letsencrypt-gandi:gandi-shs-vhost VHOST \
            --letsencrypt-gandi:gandi-shs-api-key API-KEY \
        --installer letsencrypt-gandi:gandi-shs
```